### PR TITLE
touying-unistra-pristine:1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# v1.3.0 (2024-12-23)
+
+## General
+
+- Updated to Touying 0.5.5.
+
+### Slides
+
+- **Outline Slides**:
+  - New slide type.
+    - Invoked using the `outline-slide()` function.
+    - Automatically generates a table of contents that lists focus slides from the presentation.
+      - Set the new `outline` parameter to `false` in the `focus-slide()` function to exclude a slide from the table of contents.
+    - Takes the following parameters:
+      - `title` (str): The title of the slide. Default: "Outline".
+      - `title-size` (length): The size of the title. Default: 1.5em.
+      - `content-size` (length): The size of the content. Default: 1.2em.
+      - `fill` (color): The fill color of the outline block. Default: nblue.D.
+      - `outset` (length): The outset of the outline block. Default: 30pt.
+      - `height` (ratio): The height of the outline block. Default: 80%.
+      - `radius` (ratio): The radius of the outline block. Default: 7%.
+      - `..args`: Additional arguments to pass to the outline.
+- **Appendix Slides**:
+  - Added custom footer label support for appendix slides (slides that appear after `#show: appendix`, e.g. bibliography).
+    - By default, an italic "A-" label will be shown in the footer right before the slide number. The content of the label can be changed using the settings (see below).
+
+### Settings
+
+- Added new settings to further customize the custom `quote` element:
+  - `margin-top` (relative | fraction): The top margin of the quote. Default: 0em.
+  - `outset` (relative | dictionary): The outset of the quote box. Default: 0.5em.
+  - These settings should be specified in the `config-store()` object under the `quote` key, when initializing `unistra-theme`.
+- Added `footer-appendix-label` (str) setting to customize the label shown in the footer for appendix slides. Default: "A-".
+
+### Other
+
+- Replaced the default [‣] first-child item list marker with [--] to fix alignment issues.
+
 # v1.2.0 (2024-11-21)
 
 ## General
@@ -18,7 +56,7 @@
 
 ### Admonitions
 
-- Admonitions now allow the following optional arguments:
+- Admonitions now allow the following optional parameters:
   - `lang` (str, default: "fr"): the language to show the admonition title in. Accepts one of the langs in the `ADMONITION-TRANSLATIONS` dict.
   - `plural` (bool, default: false): whether the admonition title should be plural.
   - `show-numbering` (bool, default: false): whether the admonition number should be appended before the title. This replaces the old `ADMONITION-NUMBERING` setting in `settings.typ`, and allows for individual admonition customization.
@@ -28,7 +66,7 @@
 - Added support for `short-title` and `short-subtitle` parameters in `config-info` object.
 - Reduced list item spacing to `1em`.
 
-### Fixes
+## Fixes
 
 - Minor fixes to positioning.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ These steps assume that you already have [Typst](https://typst.app/) installed a
 ## Import from Typst Universe
 
 ```typst
-#import "@preview/touying:0.5.3": *
-#import "@preview/touying-unistra-pristine:1.2.0": *
+#import "@preview/touying:0.5.5": *
+#import "@preview/touying-unistra-pristine:1.3.0": *
 
 #show: unistra-theme.with(
   aspect-ratio: "16-9",
@@ -62,7 +62,7 @@ A slide with *important information*.
 See [example/example.typ](example/example.typ) for a complete example with configuration.
 
 ```typst
-#import "@preview/touying:0.5.3": *
+#import "@preview/touying:0.5.5": *
 #import "src/unistra.typ": *
 #import "src/colors.typ": *
 #import "src/admonition.typ": *

--- a/example/example.typ
+++ b/example/example.typ
@@ -1,5 +1,5 @@
-#import "@preview/touying:0.5.3": *
-#import "@preview/touying-unistra-pristine:1.2.0": *
+#import "@preview/touying:0.5.5": *
+#import "@preview/touying-unistra-pristine:1.3.0": *
 
 #show: unistra-theme.with(
   aspect-ratio: "16-9",
@@ -10,10 +10,12 @@
     date: datetime.today().display("[month repr:long] [day], [year repr:full]"),
     logo: image("../assets/unistra.svg"),
   ),
-  config-store(quotes: (
-    left: "‘",
-    right: "’",
-  )),
+  config-store(
+    quotes: (
+      left: "‘",
+      right: "’",
+    ),
+  ),
 )
 
 #title-slide(logo: image("../assets/unistra.svg"))
@@ -39,7 +41,11 @@ This is #highlight(fill: blue.C)[highlighted in blue]. This is #highlight(fill: 
 #hero(
   image("../assets/cat1.jpg", width: 100%, height: 100%),
   txt: (
-    text: "This is an " + highlight(fill: yellow.C)[RTL#footnote[RTL = right to left. Oh, and here's a footnote!] hero with text and no title] + ".\n",
+    text: "This is an "
+      + highlight(
+        fill: yellow.C,
+      )[RTL#footnote[RTL = right to left. Oh, and here's a footnote!] hero with text and no title]
+      + ".\n",
     enhanced: false,
   ),
   direction: "rtl",
@@ -120,7 +126,9 @@ This is #highlight(fill: blue.C)[highlighted in blue]. This is #highlight(fill: 
 
 #lorem(80)
 
-#quote(attribution: [from the Henry Cary literal translation of 1897 | *Noticed the custom quotes?*])[
+#quote(
+  attribution: [from the Henry Cary literal translation of 1897 | *Noticed the custom quotes?*],
+)[
   ... I seem, then, in just this little thing to be wiser than this man at
   any rate, that what I do not know I do not think I know either.
 ]

--- a/src/unistra.typ
+++ b/src/unistra.typ
@@ -186,9 +186,20 @@
           cell(
             utils.call-or-display(
               self,
-              context utils
-                .slide-counter
-                .display() + " / " + utils.last-slide-number,
+              context {
+                let current = int(utils.slide-counter.display())
+                let last = int(utils.last-slide-counter.display())
+                if current > last {
+                  (
+                    text(self.store.footer-appendix-label, style: "italic")
+                      + str(current)
+                  )
+                } else {
+                  str(current)
+                }
+              }
+                + " / "
+                + utils.last-slide-number,
             ),
           ),
         )
@@ -866,6 +877,7 @@
       // footer lower separator
       footer-lower-sep: " | ",
       footer-show-subtitle: true,
+      footer-appendix-label: "A-",
       font: ("Unistra A", "Segoe UI", "Roboto"),
       //  type of left/right quote to use for the custom "Quote" element
       quotes: (

--- a/src/unistra.typ
+++ b/src/unistra.typ
@@ -62,19 +62,6 @@
   )
 }
 
-/// Calculates page margin based on header and footer settings
-#let _get-page-margin(self) = {
-  if self.store.show-header and self.store.show-footer {
-    (x: 2.8em, y: 2.5em)
-  } else if self.store.show-header {
-    (x: 2.8em, bottom: 0em)
-  } else if self.store.show-footer {
-    (x: 2em, left: 2.8em)
-  } else {
-    (x: 1em, y: 1em)
-  }
-}
-
 // Creates a custom quote element
 #let _custom-quote(it, lquote, rquote) = {
   v(1em)

--- a/src/unistra.typ
+++ b/src/unistra.typ
@@ -1,4 +1,4 @@
-#import "@preview/touying:0.5.3": *
+#import "@preview/touying:0.5.5": *
 #import "colors.typ": *
 #import "admonition.typ": *
 
@@ -233,6 +233,29 @@
   )
 })
 
+/// Creates a outline slide with outlined headings.
+///
+/// Example:
+///
+/// ```typst
+/// #outline-slide(title: "Outline")
+/// ```
+///
+/// - `title` (str): The title of the slide. Default: "Outline".
+///
+/// - `title-size` (length): The size of the title. Default: 1.5em.
+///
+/// - `content-size` (length): The size of the content. Default: 1.2em.
+///
+/// - `fill` (color): The fill color of the outline block. Default: nblue.D.
+///
+/// - `outset` (length): The outset of the outline block. Default: 30pt.
+///
+/// - `height` (ratio): The height of the outline block. Default: 80%.
+///
+/// - `radius` (ratio): The radius of the outline block. Default: 7%.
+///
+/// - `..args`: Additional arguments to pass to the outline.
 #let outline-slide(
   title: utils.i18n-outline-title,
   title-size: 1.5em,
@@ -404,11 +427,13 @@
 ///
 /// - `theme` (str): The color theme to use. Themes are defined in src/colors.typ. Possible values: "lblue", "blue", "dblue", "yellow", "pink", "neon", "mandarine", "hazy", "smoke". Default: none.
 ///
-/// - `text-alignment` (str): The text alignment.
+/// - `text-alignment` (alignment): The text alignment.
 ///
 /// - `counter` (counter): The counter to use for titles. Will show a count-label before the title. Default: counter("focus-slide").
 ///
 /// - `show-counter` (bool): Whether to show the counter. Default: true.
+///
+/// - `outlined` (bool): Whether to outline the heading and make it appear in an outline slide. Default: true.
 ///
 /// - `body` (content): Content of the slide.
 #let focus-slide(
@@ -483,6 +508,9 @@
           height: 100%,
           grid.cell(
             heading(
+              // we define a high level to avoid the outline slide
+              // displaying other types of headings
+              // that would be outlined by default
               level: 99,
               outlined: outlined,
               if (count-label != none) {
@@ -552,7 +580,7 @@
 ///
 /// - `direction` (str): The direction of the image and text. Possible values: "ltr", "rtl", "utd", "dtu". Default: "ltr".
 ///
-/// - `gap` (str): The gap between the image and text. Default: auto.
+/// - `gap` (int | relative | fraction | array): The gap between the image and text. Default: auto.
 ///
 /// - `hide-footer` (bool): Whether to hide the footer. Default: true.
 ///
@@ -771,15 +799,15 @@
 ///
 /// - `bold-caption` (bool): Whether to make the captions bold. Default: true.
 ///
-/// - `height` (str): The height of the images. Default: auto.
+/// - `height` (length): The height of the images. Default: auto.
 ///
-/// - `width` (str): The width of the images. Default: auto.
+/// - `width` (length): The width of the images. Default: auto.
 ///
 /// - `fit` (str): The fit of the images. Can be "cover", "stretch" or "contain". Default: "cover".
 ///
-/// - `gutter` (str): The gutter between the images. Default: 0.5em.
+/// - `gutter` (int | relative | fraction | array): The gutter between the images. Default: 0.5em.
 ///
-/// - `gap` (str): The gap between the images. Default: 0.65em.
+/// - `gap` (int | relative | fraction | array): The gap between the images. Default: 0.65em.
 #let gallery(
   title: none,
   heading-level: 2,
@@ -918,7 +946,7 @@
       footer-show-subtitle: true,
       footer-appendix-label: "A-",
       font: ("Unistra A", "Segoe UI", "Roboto"),
-      //  type of left/right quote to use for the custom "Quote" element
+      // type of left/right quote to use for the custom "Quote" element
       quotes: (
         left: "« ",
         right: " »",

--- a/src/unistra.typ
+++ b/src/unistra.typ
@@ -891,7 +891,9 @@
         )
         set outline(target: heading.where(level: 1), title: none, fill: none)
         set enum(numbering: n => [*#n;.*])
-        set list(spacing: 1em)
+        //set list(spacing: 1em)
+        // the default [‣] icon does not align properly
+        set list(marker: ([•], [--]))
         set highlight(extent: 1pt)
 
         // shows

--- a/src/unistra.typ
+++ b/src/unistra.typ
@@ -63,21 +63,23 @@
 }
 
 // Creates a custom quote element
-#let _custom-quote(it, lquote, rquote) = {
-  v(1em)
+#let _custom-quote(it, lquote, rquote, outset, margin-top) = {
+  v(margin-top)
   box(
     fill: luma(220),
-    outset: 1em,
+    outset: outset,
     width: 100%,
-      // smartquote() doesn't work properly here,
-      // probably because we're in a block
-      lquote + it.body + rquote +
-      if it.attribution != none {
+    // smartquote() doesn't work properly here,
+    // probably because we're in a block
+    lquote
+      + it.body
+      + rquote
+      + if it.attribution != none {
         set text(size: 0.8em)
         linebreak()
         h(1fr)
         (it.attribution)
-      }
+      },
   )
 }
 
@@ -869,6 +871,8 @@
       quotes: (
         left: "« ",
         right: " »",
+        outset: 0.5em,
+        margin-top: 0em,
       ),
     ),
 
@@ -902,7 +906,13 @@
           underline.with(offset: 3pt, extent: -1pt)(it),
         )
         // custom quote
-        show quote: it => _custom-quote(it, self.store.quotes.at("left"), self.store.quotes.at("right"))
+        show quote: it => _custom-quote(
+          it,
+          self.store.quotes.at("left"),
+          self.store.quotes.at("right"),
+          self.store.quotes.at("outset"),
+          self.store.quotes.at("margin-top"),
+        )
         show outline.entry: it => it.body
         show outline: it => block(inset: (x: 1em), it)
         // bibliography

--- a/src/unistra.typ
+++ b/src/unistra.typ
@@ -233,6 +233,39 @@
   )
 })
 
+#let outline-slide(
+  title: utils.i18n-outline-title,
+  title-size: 1.5em,
+  content-size: 1.2em,
+  fill: nblue.D,
+  outset: 30pt,
+  height: 80%,
+  radius: 7%,
+  ..args,
+) = {
+  let body = {
+    text(
+      title-size,
+      weight: "bold",
+      title,
+    )
+    text(
+      content-size,
+      outline(
+        target: selector.or(..range(99, 100).map(l => heading.where(level: l))),
+        ..args,
+      ),
+    )
+  }
+
+  body = place(
+    block(body, fill: fill, outset: outset, height: height, radius: radius),
+    dy: -0.5em,
+  )
+
+  slide(body)
+}
+
 /// Creates a title slide with a logo, title, subtitle, author, and date.
 ///
 /// Example:
@@ -386,6 +419,7 @@
   text-alignment: center + horizon,
   counter: counter("focus-slide"),
   show-counter: true,
+  outlined: true,
   body,
 ) = touying-slide-wrapper(self => {
   assert(
@@ -448,9 +482,14 @@
           width: 100%,
           height: 100%,
           grid.cell(
-            if (count-label != none) {
-              count-label
-            } + body,
+            heading(
+              level: 99,
+              outlined: outlined,
+              if (count-label != none) {
+                count-label
+              }
+                + body,
+            ),
             align: text-alignment,
             inset: padding,
           ),

--- a/src/unistra.typ
+++ b/src/unistra.typ
@@ -139,8 +139,11 @@
 
     let has-title-and-subtitle = {
       if (
-        self.info.short-title != auto and self.info.short-subtitle != auto
-      ) or (self.info.title != auto and self.info.subtitle != auto) {
+        (
+          self.info.short-title != auto and self.info.short-subtitle != auto
+        )
+          or (self.info.title != auto and self.info.subtitle != auto)
+      ) {
         true
       } else {
         false
@@ -167,23 +170,27 @@
               text(
                 title,
                 weight: "bold",
-              ) + if self
-                .store
-                .footer-show-subtitle and has-title-and-subtitle {
-                self.store.footer-upper-sep
-              } else {
-                ""
-              } + if self.store.footer-show-subtitle {
-                if self.info.short-subtitle != auto {
-                  self.info.short-subtitle
+              )
+                + if self.store.footer-show-subtitle
+                  and has-title-and-subtitle {
+                  self.store.footer-upper-sep
                 } else {
-                  self.info.subtitle
+                  ""
                 }
-              } + "\n" + self.info.author + if self.info.date != none {
-                self.store.footer-lower-sep + self.info.date
-              } else {
-                ""
-              },
+                + if self.store.footer-show-subtitle {
+                  if self.info.short-subtitle != auto {
+                    self.info.short-subtitle
+                  } else {
+                    self.info.subtitle
+                  }
+                }
+                + "\n"
+                + self.info.author
+                + if self.info.date != none {
+                  self.store.footer-lower-sep + self.info.date
+                } else {
+                  ""
+                },
               width: 100%,
             ),
           ),
@@ -264,7 +271,8 @@
   if nb-logos == 0 {
     logo-body = logo
   } else {
-    logo-body = grid(columns: if nb-logos > 0 {
+    logo-body = grid(
+      columns: if nb-logos > 0 {
         nb-logos
       } else {
         1
@@ -285,7 +293,7 @@
         height: 100%,
         inset: (left: 2em, top: 1em),
         grid(
-          columns: (1fr),
+          columns: 1fr,
           rows: (6em, 6em, 4em, 4em),
           logo-body,
           _cell([
@@ -392,19 +400,17 @@
   if (theme != none) {
     assert(
       theme in self.store.colorthemes,
-      message: "The theme " + theme + " is not defined. Available themes are: " + self
-        .store
-        .colorthemes
-        .keys()
-        .join(", "),
+      message: "The theme "
+        + theme
+        + " is not defined. Available themes are: "
+        + self.store.colorthemes.keys().join(", "),
     )
     assert(
-      self.store.colorthemes.at(theme).len() != 2 or self
-        .store
-        .colorthemes
-        .at(theme)
-        .len() != 3,
-      message: "The theme " + theme + " is not a valid color theme. A valid color theme should have 2 or 3 colors.",
+      self.store.colorthemes.at(theme).len() != 2
+        or self.store.colorthemes.at(theme).len() != 3,
+      message: "The theme "
+        + theme
+        + " is not a valid color theme. A valid color theme should have 2 or 3 colors.",
     )
 
     let theme-has-text-color = self.store.colorthemes.at(theme).len() == 3
@@ -523,7 +529,7 @@
   caption: none,
   bold-caption: false,
   numbering: none,
-  rows: (1fr),
+  rows: 1fr,
   txt: (:),
   direction: "ltr",
   gap: auto,
@@ -567,16 +573,16 @@
   }
 
   let create-image-cell() = {
-    _cell(
-      create-figure(),
-    )
+    _cell(create-figure())
   }
 
   let create-text-cell() = {
     let new-txt = merged-txt.text
     if type(merged-txt.enhanced) == "boolean" and merged-txt.enhanced {
       new-txt = text(size: 2em, weight: 900, merged-txt.text)
-    } else if type(merged-txt.enhanced) == "boolean" and not merged-txt.enhanced {
+    } else if (
+      type(merged-txt.enhanced) == "boolean" and not merged-txt.enhanced
+    ) {
       new-txt = merged-txt.text
     } else if type(merged-txt.enhanced) == "function" {
       new-txt = (merged-txt.enhanced)(merged-txt.text)
@@ -636,7 +642,7 @@
         create-grid(
           create-image-cell(),
           create-text-cell(),
-          columns: (1fr),
+          columns: 1fr,
           rows: (1fr, 1fr),
           row-gutter: gap,
         )
@@ -644,7 +650,7 @@
         create-grid(
           create-text-cell(),
           create-image-cell(),
-          columns: (1fr),
+          columns: 1fr,
           rows: (1fr, 1fr),
           row-gutter: if gap != auto {
             gap
@@ -682,12 +688,12 @@
 
   if (title, subtitle, caption).all(x => x == none) {
     body = block(
-        body,
-        // expand image as much as possible
-        // as it is the only content
-        // todo: calculate this automatically
-        inset: inset,
-      )
+      body,
+      // expand image as much as possible
+      // as it is the only content
+      // todo: calculate this automatically
+      inset: inset,
+    )
   }
 
   let self = utils.merge-dicts(
@@ -760,31 +766,33 @@
   let body = {
     set align(center + horizon)
     grid(
-      ..figs.enumerate().map(((i, fig)) => {
-        let caption = if i < captions.len() {
-          let cap = captions.at(i)
-          if cap != "" {
-            cap
+      ..figs
+        .enumerate()
+        .map(((i, fig)) => {
+          let caption = if i < captions.len() {
+            let cap = captions.at(i)
+            if cap != "" {
+              cap
+            } else {
+              none
+            }
           } else {
             none
           }
-        } else {
-          none
-        }
 
-        if (bold-caption) {
-          caption = text(weight: "bold", caption)
-        }
+          if (bold-caption) {
+            caption = text(weight: "bold", caption)
+          }
 
-        figure(
-          fig,
-          caption: caption,
-          gap: gap,
-          numbering: none,
-        )
-      }),
+          figure(
+            fig,
+            caption: caption,
+            gap: gap,
+            numbering: none,
+          )
+        }),
       columns: columns,
-      rows: (1fr) * rows,
+      rows: 1fr * rows,
       gutter: gutter,
     )
   }

--- a/template/template.typ
+++ b/template/template.typ
@@ -1,5 +1,5 @@
-#import "@preview/touying:0.5.3": *
-#import "@preview/touying-unistra-pristine:1.2.0": *
+#import "@preview/touying:0.5.5": *
+#import "@preview/touying-unistra-pristine:1.3.0": *
 
 #show: unistra-theme.with(
   aspect-ratio: "16-9",

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "touying-unistra-pristine"
-version = "1.2.0"
+version = "1.3.0"
 entrypoint = "src/lib.typ"
 authors = [
   "Enzo Doyen <https://edoyen.com/>"


### PR DESCRIPTION
# v1.3.0 (2024-12-23)

## General

- Updated to Touying 0.5.5.

### Slides

- **Outline Slides**:
  - New slide type.
    - Invoked using the `outline-slide()` function.
    - Automatically generates a table of contents that lists focus slides from the presentation.
      - Set the new `outline` parameter to `false` in the `focus-slide()` function to exclude a slide from the table of contents.
    - Takes the following parameters:
      - `title` (str): The title of the slide. Default: "Outline".
      - `title-size` (length): The size of the title. Default: 1.5em.
      - `content-size` (length): The size of the content. Default: 1.2em.
      - `fill` (color): The fill color of the outline block. Default: nblue.D.
      - `outset` (length): The outset of the outline block. Default: 30pt.
      - `height` (ratio): The height of the outline block. Default: 80%.
      - `radius` (ratio): The radius of the outline block. Default: 7%.
      - `..args`: Additional arguments to pass to the outline.
- **Appendix Slides**:
  - Added custom footer label support for appendix slides (slides that appear after `#show: appendix`, e.g. bibliography).
    - By default, an italic "A-" label will be shown in the footer right before the slide number. The content of the label can be changed using the settings (see below).

### Settings

- Added new settings to further customize the custom `quote` element:
  - `margin-top` (relative | fraction): The top margin of the quote. Default: 0em.
  - `outset` (relative | dictionary): The outset of the quote box. Default: 0.5em.
  - These settings should be specified in the `config-store()` object under the `quote` key, when initializing `unistra-theme`.
- Added `footer-appendix-label` (str) setting to customize the label shown in the footer for appendix slides. Default: "A-".

### Other

- Replaced the default [‣] first-child item list marker with [--] to fix alignment issues.